### PR TITLE
Update to reflect documentation

### DIFF
--- a/lib/upwork/api/routers/payments.rb
+++ b/lib/upwork/api/routers/payments.rb
@@ -34,7 +34,7 @@ module Upwork
         #  params: (Hash)
         def submit_bonus(team_reference, params)
           $LOG.i "running " + __method__.to_s
-          @client.post '/hr/v2/teams/' + team_reference + '/adjustments', params
+          @client.post '/hr/v2/teams/#{team_reference}/adjustments', params
         end
       end
     end


### PR DESCRIPTION
Documentation shows the use for payments as passing a team_reference in as an integer. Passing in as an integer fails with "TypeError: no implicit conversion of Fixnum into String". Changing this post to use string interpolation fixes the issues and now reflects the proper use per the API documentation: https://developers.upwork.com/?lang=ruby#payments_make-custom-payment
