### PR TITLE
Update to reflect documentation

### DIFF
--- a/lib/upwork/api/routers/payments.rb
+++ b/lib/upwork/api/routers/payments.rb
@@ -34,7 +34,7 @@ module Upwork
         #  params: (Hash)
         def submit_bonus(team_reference, params)
           $LOG.i "running " + __method__.to_s
-          @client.post '/hr/v2/teams/' + team_reference + '/adjustments', params
+          @client.post "/hr/v2/teams/#{team_reference}/adjustments", params
         end
       end
     end


### PR DESCRIPTION
Update bonus payment post call to use string interpolation to reflect the example use in the API documentation: https://developers.upwork.com/?lang=ruby#payments_make-custom-payment

Passing team_reference as an integer fails with "TypeError: no implicit conversion of Fixnum into String"
